### PR TITLE
Fix controller data param

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -29,6 +29,6 @@ class TagsController < ApplicationController
   private
 
   def tag_params
-    params.require(:tag).permit(:user_id, :title)
+    params.require(:data).permit(:user_id, :title)
   end
 end


### PR DESCRIPTION
Controllers should require a top-level `data` object in the request JSON.